### PR TITLE
Initial commit of "clean" and "resume" flags. 

### DIFF
--- a/src/jobTree/common.py
+++ b/src/jobTree/common.py
@@ -129,8 +129,8 @@ def _addOptions(addGroupFn, defaultStr):
     addOptionFn("--rescueJobsFrequency", dest="rescueJobsFrequency",
                       help=("Period of time to wait (in seconds) between checking for "
                             "missing/overlong jobs, that is jobs which get lost by the batch system. Expert parameter. (default is set by the batch system)"))
-    addOptionFn("--resume", dest="resume", action='store_true',
-                      help=("Pass this flag to resume a previous, incomplete job with an existing jobStore"))
+    addOptionFn("--resume", dest="resume", action='store_true', default=False,
+                      help=("Pass this flag to resume a previous, incomplete job with an existing jobStore. defualt = %s" % defaultStr))
     addOptionFn("--clean", dest="clean", choices=['always', 'onerror','never'], default='always',
                       help=("Determines the deletion of the jobStore upon completion of the program. If you wish to be able to restart the run, "
                             "choose \'never\'. Default=%s" % defaultStr))
@@ -228,7 +228,6 @@ def createConfig(options):
     config.attrib["max_memory"] = str(int(options.maxMemory))
     config.attrib["max_disk"] = str(int(options.maxDisk))
     config.attrib["scale"] = str(float(options.scale))
-    config.attrib["resume"] = options.resume
     config.attrib["clean"] = options.clean
     if options.bigBatchSystem is not None:
         config.attrib["big_batch_system"] = options.bigBatchSystem
@@ -238,6 +237,8 @@ def createConfig(options):
         config.attrib["big_max_memory"] = str(int(options.bigMaxMemory))
     if options.stats:
         config.attrib["stats"] = ""
+    if options.resume:
+        config.attrib["resume"] = ""
     return config
 
 

--- a/src/jobTree/common.py
+++ b/src/jobTree/common.py
@@ -124,6 +124,11 @@ def _addOptions(addGroupFn, defaultStr):
     addOptionFn("--rescueJobsFrequency", dest="rescueJobsFrequency",
                       help=("Period of time to wait (in seconds) between checking for "
                             "missing/overlong jobs, that is jobs which get lost by the batch system. Expert parameter. (default is set by the batch system)"))
+    addOptionFn("--resume", dest="resume", action='store_true',
+                      help=("Pass this flag to resume a previous, incomplete job with an existing jobStore"))
+    addOptionFn("--clean", dest="clean", choices=['always', 'onerror','never'], default='always',
+                      help=("Determines the deletion of the jobStore upon completion of the program. If you wish to be able to restart the run, "
+                            "choose \'never\'. Default=%s" % defaultStr))
 
     addOptionFn = addGroupFn("jobTree big batch system options",
                              "jobTree can employ a secondary batch system for running large memory/cpu jobs using the following arguments:")
@@ -216,6 +221,8 @@ def createConfig(options):
     config.attrib["max_cpus"] = str(int(options.maxCpus))
     config.attrib["max_memory"] = str(int(options.maxMemory))
     config.attrib["scale"] = str(float(options.scale))
+    config.attrib["resume"] = options.resume
+    config.attrib["clean"] = options.clean
     if options.bigBatchSystem is not None:
         config.attrib["big_batch_system"] = options.bigBatchSystem
         config.attrib["big_memory_threshold"] = str(int(options.bigMemoryThreshold))

--- a/src/jobTree/leader.py
+++ b/src/jobTree/leader.py
@@ -492,6 +492,9 @@ def mainLoop(config, batchSystem, jobStore, rootJob):
         ##########################################
         #Finish up the stats/logging aggregation process
         ##########################################
+        clean = config["clean"]
+        if(clean=="always" or (clean == "onerror" and totalFailedJobs==0)):
+            jobStore.delete()
         logger.info("Waiting for stats and logging collator process to finish")
         startTime = time.time()
         stopStatsAndLoggingAggregatorProcess.put(True)

--- a/src/jobTree/leader.py
+++ b/src/jobTree/leader.py
@@ -493,7 +493,7 @@ def mainLoop(config, batchSystem, jobStore, rootJob):
         ##########################################
         #Finish up the stats/logging aggregation process
         ##########################################
-        clean = config["clean"]
+        clean = config.attrib["clean"]
         if(clean=="always" or (clean == "onerror" and totalFailedJobs==0)):
             jobStore.delete()
         logger.info("Waiting for stats and logging collator process to finish")

--- a/src/jobTree/leader.py
+++ b/src/jobTree/leader.py
@@ -493,13 +493,13 @@ def mainLoop(config, batchSystem, jobStore, rootJob):
         ##########################################
         #Finish up the stats/logging aggregation process
         ##########################################
-        clean = config.attrib["clean"]
-        if(clean=="always" or (clean == "onerror" and totalFailedJobs==0)):
-            jobStore.delete()
         logger.info("Waiting for stats and logging collator process to finish")
         startTime = time.time()
         stopStatsAndLoggingAggregatorProcess.put(True)
         worker.join()
         logger.info("Stats/logging finished collating in %s seconds", time.time() - startTime)
+        clean = config.attrib["clean"]
+        if(clean=="always" or (clean == "onerror" and totalFailedJobs==0)):
+            jobStore.deleteJobStore()
 
     return totalFailedJobs #Returns number of failed jobs


### PR DESCRIPTION
The jobStore will now always delete unless specified otherwise, and trying to restart with an existing jobStore will fail unless the --resume flag has been passed
