### PR TITLE
Work directory flag

### DIFF
--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -82,7 +82,8 @@ def _addOptions(addGroupFn, defaultStr):
                             "If you pass an existing directory it will check if it's a valid existing "
                             "jobtree, then try and restart the jobs in it. The default=%s" % defaultStr))
     addOptionFn("--workDir", dest="workDir", default='/tmp',
-                      help="Where temporary files generated during the Toil run should be placed. default=%s" % defaultStr)
+                      help="Absolute path to directory where temporary files generated during the Toil run should "
+                           "be placed. default=%s" % defaultStr)
     addOptionFn("--stats", dest="stats", action="store_true", default=False,
                       help="Records statistics about the batchjob-tree to be used by toilStats. default=%s" % defaultStr)
 

--- a/src/toil/common.py
+++ b/src/toil/common.py
@@ -81,6 +81,8 @@ def _addOptions(addGroupFn, defaultStr):
                             "(If this is a file path this needs to be globally accessible by all machines running jobs).\n"
                             "If you pass an existing directory it will check if it's a valid existing "
                             "jobtree, then try and restart the jobs in it. The default=%s" % defaultStr))
+    addOptionFn("--workDir", dest="workDir", default='/tmp',
+                      help="Where temporary files generated during the Toil run should be placed. default=%s" % defaultStr)
     addOptionFn("--stats", dest="stats", action="store_true", default=False,
                       help="Records statistics about the batchjob-tree to be used by toilStats. default=%s" % defaultStr)
 
@@ -209,6 +211,7 @@ def createConfig(options):
     config = ET.Element("config")
     config.attrib["log_level"] = getLogLevelString()
     config.attrib["master_ip"] = options.masterIP
+    config.attrib["work_dir"] = options.workDir
     config.attrib["job_store"] = os.path.abspath(options.toil) if options.toil.startswith('.') else options.toil
     config.attrib["parasol_command"] = options.parasolCommand
     config.attrib["try_count"] = str(int(options.retryCount) + 1)

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -141,13 +141,15 @@ def main():
                 sys.path.append(e)
 
     setLogLevel(config.attrib["log_level"])
+    # Priority: Flag if set to non-default, then environment variable if set, then flag default
+    tempRootDir= config.attrib["work_dir"] if config.attrib["work_dir"]!='/tmp' else environment["TMPDIR"] if environment["TMPDIR"] else config.attrib["work_dir"]
 
     ##########################################
     #Setup the temporary directories.
     ##########################################
         
     #Dir to put all the temp files in.
-    localWorkerTempDir = getTempDirectory()
+    localWorkerTempDir = getTempDirectory(tempRootDir)
     
     ##########################################
     #Setup the logging

--- a/src/toil/worker.py
+++ b/src/toil/worker.py
@@ -142,7 +142,10 @@ def main():
 
     setLogLevel(config.attrib["log_level"])
     # Priority: Flag if set to non-default, then environment variable if set, then flag default
-    tempRootDir= config.attrib["work_dir"] if config.attrib["work_dir"]!='/tmp' else environment["TMPDIR"] if environment["TMPDIR"] else config.attrib["work_dir"]
+    if "TMPDIR" in environment and config.attrib["work_dir"]!='/tmp':
+        tempRootDir = environment["TMPDIR"]
+    else:
+        tempRootDir= config.attrib["work_dir"]
 
     ##########################################
     #Setup the temporary directories.


### PR DESCRIPTION
Allow user to specify where temporary files will be stored. Especially important on AWS where the default /tmp is mounted on a tiny EBS volume, prone to filling up. 
